### PR TITLE
Rating bar precision

### DIFF
--- a/example/src/main/java/com/fuzzproductions/ratingbarexample/MainActivity.java
+++ b/example/src/main/java/com/fuzzproductions/ratingbarexample/MainActivity.java
@@ -21,7 +21,57 @@ public class MainActivity extends AppCompatActivity {
 
         textView = (TextView) findViewById(R.id.justsometext);
 
-        final RatingBar bar = (RatingBar) findViewById(R.id.rating_bar);
+        final RatingBar barWithoutSelect = (RatingBar) findViewById(R.id.rating_bar_without_select);
+        final RatingBar barWithSelect = (RatingBar) findViewById(R.id.rating_bar_with_select);
+        bindRatingBar(barWithoutSelect);
+        bindRatingBar(barWithSelect);
+
+        View b = findViewById(R.id.random_starSize);
+        if (b != null) {
+            b.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+
+                    Random r = new Random(System.currentTimeMillis());
+                    int size = r.nextInt(100);
+                    setStarSizeInDp(barWithoutSelect, size);
+                    setStarSizeInDp(barWithSelect, size);
+
+                }
+            });
+        }
+
+        b = findViewById(R.id.random_starCount);
+        if (b != null) {
+            b.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+
+                    Random r = new Random(System.currentTimeMillis());
+                    int count = r.nextInt(10);
+                    setStarCount(barWithoutSelect, count);
+                    setStarCount(barWithSelect, count);
+
+                }
+            });
+        }
+
+
+    }
+
+    private void setStarCount(RatingBar bar, int count) {
+        if (bar != null) {
+            bar.setMax(count);
+        }
+    }
+
+    private void setStarSizeInDp(RatingBar bar, int size) {
+        if (bar != null) {
+            bar.setStarSizeInDp(size);
+        }
+    }
+
+    private void bindRatingBar(RatingBar bar) {
         if (bar != null) {
             bar.setOnRatingBarChangeListener(new RatingBar.OnRatingBarChangeListener() {
                 @Override
@@ -49,37 +99,5 @@ public class MainActivity extends AppCompatActivity {
 //            });
 
         }
-
-        View b = findViewById(R.id.random_starSize);
-        if (b != null) {
-            b.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-
-                    Random r = new Random(System.currentTimeMillis());
-                    if (bar != null) {
-                        bar.setStarSizeInDp(r.nextInt(100));
-                    }
-
-                }
-            });
-        }
-
-        b = findViewById(R.id.random_starCount);
-        if (b != null) {
-            b.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-
-                    Random r = new Random(System.currentTimeMillis());
-                    if (bar != null) {
-                        bar.setMax(r.nextInt(10));
-                    }
-
-                }
-            });
-        }
-
-
     }
 }

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -17,13 +17,29 @@
         android:layout_centerHorizontal="true" />
 
     <com.fuzzproductions.ratingbar.RatingBar
-        android:id="@+id/rating_bar"
+        android:id="@+id/rating_bar_without_select"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:layout_margin="10dp"
         app:minAllowedStars="1"
         app:numStars="7"
+        app:selectTheTappedRating="false"
+        app:rating="2.5"
+        app:starMargin="5dp"
+        app:starSize="20dp"
+        app:stepSize=".5" />
+
+    <com.fuzzproductions.ratingbar.RatingBar
+        android:id="@+id/rating_bar_with_select"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:layout_below="@id/rating_bar_without_select"
+        android:layout_margin="10dp"
+        app:minAllowedStars="1"
+        app:numStars="7"
+        app:selectTheTappedRating="true"
         app:rating="2.5"
         app:starMargin="5dp"
         app:starSize="20dp"
@@ -33,7 +49,7 @@
         style="?android:attr/buttonBarStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/rating_bar"
+        android:layout_below="@id/rating_bar_with_select"
         android:layout_centerHorizontal="true">
 
         <Button

--- a/library/src/main/java/com/fuzzproductions/ratingbar/RatingBar.java
+++ b/library/src/main/java/com/fuzzproductions/ratingbar/RatingBar.java
@@ -412,9 +412,7 @@ public class RatingBar extends View {
                         mStepSize = 0.1f;
                     }
 
-                    selectedAmount = (((x - xPerStar) / xPerStar) + 1);
-                    float remainder = selectedAmount % mStepSize;
-                    selectedAmount = selectedAmount - remainder;
+                    selectedAmount = getSelectedRating(x, xPerStar, RatingBar.this.mStepSize);
                 }
             }
             if (x < 0) {
@@ -431,6 +429,26 @@ public class RatingBar extends View {
             return true;
         }
     };
+
+    /**
+     * Given the x-coordinate of a point somewhere within this {@link RatingBar}.
+     * <p>
+     *     Returned value must be an integer multiple of {@code stepSize}.
+     * </p>
+     *
+     * @param xOfRating x-coordinate (in pixels) of a proposed rating value
+     * @param xPerStar  how many pixels (in the x direction) correspond to one star
+     * @param stepSize  the smallest individual unit of a rating
+     * @return an accepted rating value
+     */
+    protected float getSelectedRating(float xOfRating, int xPerStar, float stepSize) {
+        float selectedAmount = (((xOfRating - xPerStar) / xPerStar) + 1);
+        float remainder = selectedAmount % stepSize;
+
+        selectedAmount = selectedAmount - remainder;
+
+        return selectedAmount;
+    }
 
     //Interfaces
 

--- a/library/src/main/java/com/fuzzproductions/ratingbar/RatingBar.java
+++ b/library/src/main/java/com/fuzzproductions/ratingbar/RatingBar.java
@@ -32,6 +32,7 @@ public class RatingBar extends View {
     private int mStarSize = 0;
     private boolean isIndicator = false;
     private float mStepSize = 1;
+    private boolean selectTheTappedRating = false;
 
     @DrawableRes
     private int filledDrawable;
@@ -87,6 +88,7 @@ public class RatingBar extends View {
             mRating = a.getFloat(R.styleable.RatingBar_rating, mMinSelectionAllowed);
             isIndicator = a.getBoolean(R.styleable.RatingBar_isIndicator, false);
             mStepSize = a.getFloat(R.styleable.RatingBar_stepSize, 1);
+            selectTheTappedRating = a.getBoolean(R.styleable.RatingBar_selectTheTappedRating, false);
             a.recycle();
         } else {
             setDefaultDrawables();
@@ -446,6 +448,11 @@ public class RatingBar extends View {
         float remainder = selectedAmount % stepSize;
 
         selectedAmount = selectedAmount - remainder;
+
+        if (selectTheTappedRating) {
+            float directionalStep = Math.signum(remainder) * stepSize;
+            selectedAmount += directionalStep;
+        }
 
         return selectedAmount;
     }

--- a/library/src/main/java/com/fuzzproductions/ratingbar/RatingBar.java
+++ b/library/src/main/java/com/fuzzproductions/ratingbar/RatingBar.java
@@ -134,6 +134,10 @@ public class RatingBar extends View {
         setRating(rating, false);
     }
 
+    public void setShouldSelectTheTappedRating(boolean selectTheTappedRating) {
+        this.selectTheTappedRating = selectTheTappedRating;
+    }
+
     /**
      * @return Returns the current rating
      */

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -11,5 +11,6 @@
         <attr name="starMargin" format="dimension" />
         <attr name="isIndicator" format="boolean"/>
         <attr name="stepSize" format="float"/>
+        <attr name="selectTheTappedRating" format="boolean"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This is a proposed fix for issue #18. It introduces a new attribute flag to the RatingBar xml, which tries to select the section that is tapped ('rounding up', so to speak) instead of truncating that rating ('rounding down').

I plan to add one more commit to allow this flag to be set through a simple setter on the view, then I think that'll be ready for merging.